### PR TITLE
Fix R CMD check notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^.renvignore$
+^CHANGELOG\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ Description: Compute multiple types of correlations analysis (Pearson correlatio
   This package also has a C++ implementation of the Average correlation clustering algorithm and distance correlation t-test.
 Depends: 
     R (>= 3.6.0),
-    Rcpp (>= 1.0.4.6),
 Imports: 
+    Rcpp (>= 1.0.4.6),
     RcppArmadillo,
     lsr (>= 0.5),
     parallel,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,9 @@ Imports:
     checkmate (>= 2.0.0),
     ppsr (>= 0.0.2),
     DescTools(>= 0.99.40)
-Suggests: testthat
+Suggests: 
+    energy,
+    testthat
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     ppsr (>= 0.0.2),
     DescTools(>= 0.99.40)
 Suggests: 
+    corrplot,
     energy,
     testthat
 License: GPL (>= 3)


### PR DESCRIPTION
R packages should pass R CMD check without errors, warnings, or notes

This PR fixes two notes:
* Add the energy package to suggests since you link to it in the docs
* Build ignore the changelog file so it is not bundled in the R package

Part of the review at openjournals/joss-reviews#7319