### PR TITLE
Jromanowska review

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -105,3 +105,14 @@ author = {Anindya Bhattacharya and Rajat K. De}
   note         = {Accessed: 2025-03-26}
 }
 
+
+@Manual{laeken:2024,
+  title        = {laeken: Estimation of indicators on social exclusion and poverty, as well as Pareto tail modeling for empirical income distributions},
+  author       = {Andreas Alfons and Matthias Templ and Peter Filzmoser},
+  year         = {2024},
+  note         = {R package version 0.5.3},
+  url          = {https://CRAN.R-project.org/package=laeken}
+}
+
+
+

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -97,3 +97,11 @@ author = {Anindya Bhattacharya and Rajat K. De}
   url          = {https://cran.r-project.org/package=Hmisc}
 }
 
+@Misc{sidekicks:2025,
+  author       = {Srikanth Komala Sheshachala},
+  title        = {sidekicks: A Misc Set of Functions for Data Analysis},
+  year         = {2025},
+  howpublished = {\url{https://github.com/talegari/sidekicks}},
+  note         = {Accessed: 2025-03-26}
+}
+

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -79,3 +79,21 @@ doi = {10.1016/j.jbi.2010.02.001},
 url = {https://www.sciencedirect.com/science/article/pii/S1532046410000158},
 author = {Anindya Bhattacharya and Rajat K. De}
 }
+
+
+@Manual{stats:2024,
+  title        = {The R Stats Package: Statistical Functions},
+  author       = {{R Core Team}},
+  year         = {2024},
+  note         = {R package version 4.6.0},
+  url          = {https://stat.ethz.ch/R-manual/R-devel/library/stats/html/00Index.html}
+}
+
+@Manual{Hmisc:2025,
+  title        = {Hmisc: Harrell Miscellaneous},
+  author       = {Frank E. Harrell Jr},
+  year         = {2025},
+  note         = {R package version 5.2-3},
+  url          = {https://cran.r-project.org/package=Hmisc}
+}
+

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,7 +34,7 @@ In this package, the ACCA algorithm has been extended to work directly with corr
 
 The `corrp` package is an R package that provides a flexible and efficient way of performing correlation-like analysis on mixed-type data frames. These datasets can contain different variable types, such as continuous (numeric), ordinal (ordered categorical), and nominal (unordered categorical) variables, which frequently arise in practical scenarios.
 
-Moreover, most traditional correlation methods in R apply only to specific data types or small datasets. In this sense, `corrp` extends this capability by handling mixed data types, integrating various association methods, and offering clustering directly from the resulting correlation matrix.
+Moreover, most traditional correlation methods in R — such as `cor()` from the [stats package][@stats:2024], which computes Pearson, Spearman, or Kendall correlations between vectors, matrices, or data frames; and `rcorr()` from the [Hmisc package][@Hmisc:2025], which efficiently computes Pearson or Spearman correlation matrices — are primarily designed for specific data types and may not generalize well to mixed data or large-scale applications. In this sense, `corrp` extends these capabilities by handling mixed data types, integrating various association methods, and offering clustering directly from the resulting correlation matrix..
 
 The `corrp` package automatically detects the variable types present in the dataset. However, manual intervention is needed to select the appropriate correlation measure for each detected variable pair (numeric pairs, categorical pairs, and numeric-categorical pairs) from the available options, as explained in more detail below.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -116,7 +116,7 @@ head(results$data)
 </div>
 
 
-When choosing correlation methods, it's important to think about their performance for different pair types. For **numeric pairs**, **Pearson** (`?`) is the quickest and most efficient option, while the **Maximal Information Coefficient** (`mic`) is significantly slower, making it less suitable for large datasets. **Distance correlation** (`dcor`) is a better performer than MIC but still not the fastest choice, while **Predictive Power Score** (`pps`) is efficient but may take longer than Pearson. For **numeric-categorical pairs**, the **linear model** (`lm`) typically outperforms `pps`. In **categorical pairs**, **Cramér's V** (`?`), **Uncertainty Coefficient** (`uncoef`), and `pps` are options, with `uncoef` being the slowest of the three.
+When choosing correlation methods, it's important to think about their performance for different pair types. For **numeric pairs**, **Pearson** (`pearson`) is the quickest and most efficient option, while the **Maximal Information Coefficient** (`mic`) is significantly slower, making it less suitable for large datasets. **Distance correlation** (`dcor`) is a better performer than MIC but still not the fastest choice, while **Predictive Power Score** (`pps`) is efficient but may take longer than Pearson. For **numeric-categorical pairs**, the **linear model** (`lm`) typically outperforms `pps`. In **categorical pairs**, **Cramér's V** (`cramersV`), **Uncertainty Coefficient** (`uncoef`), and `pps` are options, with `uncoef` being the slowest of the three.
 
 As the number of columns in the data increases, the runtime will also increase due to the `N * N` scaling. Therefore, the user should choose the methods wisely to ensure efficient performance.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -84,7 +84,7 @@ The `corrp` package provides seven main functions for correlation calculations, 
 - **sil_acca**: A C++ implementation of the Silhouette method for interpreting and validating the consistency of clusters within ACCA clusters of data.
 - **best_acca**: Determining the optimal number of clusters in ACCA clustering using the average silhouette approach.
 
-We calculate correlations for the *eusilc* dataset using the MIC for numeric pairs, PPS for numeric/categorical pairs, and Uncertainty Coefficient for categorical pairs. This synthetic dataset represents Austrian EU-SILC data on income, demographics, and household characteristics [REF?].
+We calculate correlations for the *eusilc* dataset using the MIC for numeric pairs, PPS for numeric/categorical pairs, and Uncertainty Coefficient for categorical pairs. This synthetic dataset represents Austrian EU-SILC data on income, demographics, and household characteristics [@laeken:2024].
 
 ```r
 set.seed(2024)

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,7 +34,7 @@ In this package, the ACCA algorithm has been extended to work directly with corr
 
 The `corrp` package is an R package that provides a flexible and efficient way of performing correlation-like analysis on mixed-type data frames. These datasets can contain different variable types, such as continuous (numeric), ordinal (ordered categorical), and nominal (unordered categorical) variables, which frequently arise in practical scenarios.
 
-Moreover, most traditional correlation methods in R — such as `cor()` from the [stats package][@stats:2024], which computes Pearson, Spearman, or Kendall correlations between vectors, matrices, or data frames; and `rcorr()` from the [Hmisc package][@Hmisc:2025], which efficiently computes Pearson or Spearman correlation matrices — are primarily designed for specific data types and may not generalize well to mixed data or large-scale applications. In this sense, `corrp` extends these capabilities by handling mixed data types, integrating various association methods, and offering clustering directly from the resulting correlation matrix..
+Moreover, most traditional correlation methods in R — such as `cor()` from the *stats package* [@stats:2024], which computes Pearson, Spearman, or Kendall correlations between vectors, matrices, or data frames; and `rcorr()` from the *Hmisc package* [@Hmisc:2025], which efficiently computes Pearson or Spearman correlation matrices — are primarily designed for specific data types and may not generalize well to mixed data or large-scale applications. In this sense, `corrp` extends these capabilities by handling mixed data types, integrating various association methods, and offering clustering directly from the resulting correlation matrix..
 
 The `corrp` package automatically detects the variable types present in the dataset. However, manual intervention is needed to select the appropriate correlation measure for each detected variable pair (numeric pairs, categorical pairs, and numeric-categorical pairs) from the available options, as explained in more detail below.
 
@@ -172,7 +172,7 @@ This highlights a substantial reduction in both memory usage and execution time,
 
 # Acknowledgements
 
-We acknowledge the contributions of the Meantrix team (https://github.com/meantrix) and thank Srikanth Komala Sheshachala (https://github.com/talegari) for the initial inspiration from the `cor2` function [REF].
+We acknowledge the contributions of the Meantrix team (https://github.com/meantrix) and thank Srikanth Komala Sheshachala (https://github.com/talegari) for the initial inspiration from the `cor2` function [@sidekicks:2025].
 
 # References
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -104,24 +104,16 @@ results <- corrp(
 head(results$data)
 ```
 
-|      | infer               | infer.value | stat    | stat.value |
-|------|---------------------|-------------|---------|------------|
-| 1    | Distance Correlation| 1.000       | P-value | 0.000      |
-| 2    | Distance Correlation| 0.008       | P-value | 0.000      |
-| 3    | Linear Model        | 0.146       | P-value | 3.57e-64   |
-| 4    | Linear Model        | 0.071       | P-value | 4.79e-18   |
-| 5    | Distance Correlation| 0.008       | P-value | 0.000      |
-| 6    | Distance Correlation| 1.000       | P-value | 0.000      |
-
-|      | isig | msg | varx       | vary       |
-|------|------|-----|------------|------------|
-| 1    | TRUE |     | House_Size | House_Size |
-| 2    | TRUE |     | House_Size | Income     |
-| 3    | TRUE |     | House_Size | State      |
-| 4    | TRUE |     | House_Size | Sex        |
-| 5    | TRUE |     | Income     | House_Size |
-| 6    | TRUE |     | Income     | Income     |
-
+<div style="font-size: 9px;">
+| # | infer               | infer.value | stat    | stat.value | isig | msg | varx       | vary       |
+|---|---------------------|--------------|---------|------------|------|-----|------------|------------|
+| 1 | Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | House_Size | House_Size |
+| 2 | Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | House_Size | Income     |
+| 3 | Linear Model        | 0.146        | P-value | 3.57e-64   | TRUE |     | House_Size | State      |
+| 4 | Linear Model        | 0.071        | P-value | 4.79e-18   | TRUE |     | House_Size | Sex        |
+| 5 | Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | Income     | House_Size |
+| 6 | Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | Income     | Income     |
+</div>
 
 
 When choosing correlation methods, it's important to think about their performance for different pair types. For **numeric pairs**, **Pearson** (`?`) is the quickest and most efficient option, while the **Maximal Information Coefficient** (`mic`) is significantly slower, making it less suitable for large datasets. **Distance correlation** (`dcor`) is a better performer than MIC but still not the fastest choice, while **Predictive Power Score** (`pps`) is efficient but may take longer than Pearson. For **numeric-categorical pairs**, the **linear model** (`lm`) typically outperforms `pps`. In **categorical pairs**, **Cramér's V** (`?`), **Uncertainty Coefficient** (`uncoef`), and `pps` are options, with `uncoef` being the slowest of the three.

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -105,14 +105,14 @@ head(results$data)
 ```
 
 <div style="font-size: 9px;">
-| # | infer               | infer.value | stat    | stat.value | isig | msg | varx       | vary       |
-|---|---------------------|--------------|---------|------------|------|-----|------------|------------|
-| 1 | Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | House_Size | House_Size |
-| 2 | Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | House_Size | Income     |
-| 3 | Linear Model        | 0.146        | P-value | 3.57e-64   | TRUE |     | House_Size | State      |
-| 4 | Linear Model        | 0.071        | P-value | 4.79e-18   | TRUE |     | House_Size | Sex        |
-| 5 | Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | Income     | House_Size |
-| 6 | Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | Income     | Income     |
+| infer               | infer.value | stat    | stat.value | isig | msg | varx       | vary       |
+| --------------------|--------------|---------|------------|------|-----|------------|------------|
+| Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | House_Size | House_Size |
+| Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | House_Size | Income     |
+| Linear Model        | 0.146        | P-value | 3.57e-64   | TRUE |     | House_Size | State      |
+| Linear Model        | 0.071        | P-value | 4.79e-18   | TRUE |     | House_Size | Sex        |
+| Distance Correlation| 0.008        | P-value | 0.000      | TRUE |     | Income     | House_Size |
+| Distance Correlation| 1.000        | P-value | 0.000      | TRUE |     | Income     | Income     |
 </div>
 
 


### PR DESCRIPTION
Hello @Jromanowska, all the changes requested in https://github.com/meantrix/corrp/pull/37  
have been implemented in this PR:

- Fixed the reference to the `cor2` function;
- Fixed the reference to the `eusilc` table;
- Fixed parameter names for methods in the paper text;
- Expanded the paragraph about traditional correlation methods in R. This part of the paper may also be relevant and complements the requested change:
 
```
In R, various statistical functions are available to measure these correlations. Below follows a list of correlation techniques and their corresponding R functions:  

- **Linear Model** → `stats::lm`  
- **Pearson Correlation** → `stats::cor.test`  
- **Distance Correlation** → `corrp::dcorT_test`  
- **MIC** → `minerva::mine`  
- **PPS** → `ppsr::score`  
- **Uncertainty Coefficient** → `DescTools::UncertCoef`  
- **Cramer's V** → `lsr::cramersV`
```

- Fixed the formatting of the unified table, which was previously displaying as two separate ones.

Additionally, regarding the other PR you opened (https://github.com/meantrix/corrp/pull/38) about the README on the `main` branch:  
this branch is quite outdated. All corrections, including to the README file, have been made and merged into the `JOSS` branch.  
Could you please review the text in that branch instead?


